### PR TITLE
chore: update Maven Wrapper configuration and Spring Boot parent version

### DIFF
--- a/libraryapi/.mvn/wrapper/maven-wrapper.properties
+++ b/libraryapi/.mvn/wrapper/maven-wrapper.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-wrapperVersion=3.3.2
+wrapperVersion=3.10.1
 distributionType=only-script
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/libraryapi/pom.xml
+++ b/libraryapi/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.4</version>
+		<version>3.3.5</version>
 		<relativePath/> <!-- lookup parent from authorRepository -->
 	</parent>
 


### PR DESCRIPTION
- Updated .mvn/wrapper/maven-wrapper.properties to fix Maven Wrapper setup.
- Upgraded spring-boot-starter-parent to version 3.3.5 in pom.xml."